### PR TITLE
[fix] Aired date not correctly displayed in Kodi.

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="plugin.video.ctuplinkrss" version="1.2" name="heise c't uplink" provider-name="Unofficial - Oscar Open">
+<addon id="plugin.video.ctuplinkrss" version="1.3" name="heise c't uplink" provider-name="Unofficial - Oscar Open">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.feedparser" version="6.0.2"/>
@@ -15,7 +15,7 @@
         <platform>all</platform>
         <license>GPL-3.0-only</license>
         <source>https://github.com/oscaropenness/plugin.video.ctuplinkrss</source>
-	<news>v1.2 (2021-04-09) [fix] release for Kodi 19 Matrix
+	<news>v1.3 (2023-09-01) [fix] Aired date not correctly displayed in Kodi.
 	</news>
         <assets>
             <icon>icon.png</icon>

--- a/resources/lib/ctuplinkrss.py
+++ b/resources/lib/ctuplinkrss.py
@@ -8,12 +8,17 @@
 # eine etwas schönere und umfangreiche Version 
 # finden Sie unter plugin.audio.ctuplink_audio
 
+import datetime
 import sys
 import xbmcgui
 import xbmcplugin
 import xbmcaddon
 import feedparser
 
+def convert_rfc1123_to_datetime(date_time):
+    #Bsp.: Sat, 26 Aug 2023 06:30:00 +0200
+    format = '%a, %d %b %Y %H:%M:%S %z'
+    return datetime.datetime.strptime(date_time, format)
 
 def run():
     #Selbst-Referenzierung fürs Plug-in
@@ -32,8 +37,8 @@ def run():
     for item in d['entries']:
         title = item['title']
         url = item.enclosures[0].href
-        date = item['published']
-        
+        date = str(convert_rfc1123_to_datetime(item['published']).date())
+
         #Beschreibung der Folge auslesen, für Audio nicht notwendig, aber für Audio praktisch
         summary = item['description']    
         


### PR DESCRIPTION
Publish date needs to be converted from RFC1123 format to Kodi's "DB format", because 'aired' property expects the info in this format.